### PR TITLE
Add insert and log helpers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,3 +26,28 @@ module.exports.notify = function(func) {
     return value;
   };
 };
+
+/** insert
+ *  @function
+ *  @name insert
+ *  @param {string} key
+ *  @param {value} insertable
+ *  @return {function} insertion helper
+ */
+module.exports.insert = function(key, value) {
+  return function(object) {
+    object[key] = value;
+    return object;
+  };
+};
+
+/** log
+ *  @function
+ *  @name log
+ *  @param {value} promise value
+ *  @return {value} promise value
+ */
+module.exports.log = function(promiseValue) {
+  console.log(promiseValue);
+  return promiseValue;
+};

--- a/test/promise-helpers-spec.js
+++ b/test/promise-helpers-spec.js
@@ -6,6 +6,8 @@ var sinonChai = require('sinon-chai');
 var promiseHelpers = require('../src/index.js');
 var wrap = promiseHelpers.wrap;
 var notify = promiseHelpers.notify;
+var insert = promiseHelpers.insert;
+var log = promiseHelpers.log;
 
 
 chai.should();
@@ -35,6 +37,22 @@ describe('promise utility functions', function() {
 
     it('closure returns the value passed to it', function() {
       notifyFunc(321).should.equal(321);
+    });
+  });
+
+  describe('insert', function() {
+    it('places values in an object and returns the object', function() {
+      insert('key', 'value')({})
+        .should.deep.equal({
+          key: 'value'
+        });
+    });
+  });
+
+  describe('log', function() {
+    it('returns the promise value', function() {
+      log('promise value')
+        .should.equal('promise value');
     });
   });
 });


### PR DESCRIPTION
Insert allows the user to insert arbitrary javascript values into a promise value (assuming it is an object)

Log allows the user to debug or log promise values.
